### PR TITLE
[B] Remove unused param

### DIFF
--- a/components/ComponentBase.php
+++ b/components/ComponentBase.php
@@ -102,7 +102,7 @@ abstract class ComponentBase extends Base
         $funcObj = new \Twig_SimpleFunction($funcName, $realCallable, [
             'needs_context' => true,
         ]);
-        $this->twig->addFunction($funcName, $funcObj);
+        $this->twig->addFunction($funcObj);
 
 
     }


### PR DESCRIPTION
The impetus here was the MOCA October upgrade. The change has been tested on other October projects without issue, so this should be safe to merge.